### PR TITLE
fix for #2

### DIFF
--- a/src/state/Draw.js
+++ b/src/state/Draw.js
@@ -8,11 +8,18 @@ export default class Draw {
 
   initialize() {
     this._mouseTracker = function (e) {
-      this.x = e.offsetX;
-      this.y = e.offsetY;
+      var offsetX = e.clientX - this.rect.left,
+					offsetY = e.clientY - this.rect.top;
+      console.log("mousetracker rect"+this.rect.left+","+this.rect.top+" offset:"+offsetX+","+offsetY);
+      this.x = offsetX;
+      this.y = offsetY;
     }.bind(this);
     this._onMouseDown = function (e) {
-      this.handleMouseDown(e.offsetX, e.offsetY);
+      var target = e.target || e.srcElement;
+			this.rect = target.getBoundingClientRect();
+			var	offsetX = e.clientX - this.rect.left,
+			    offsetY = e.clientY - this.rect.top;
+      this.handleMouseDown(offsetX,offsetY);
       e.stopPropagation();
     }.bind(this);
     this._onMouseUp = function () {


### PR DESCRIPTION
calculating the offset using http://www.jacklmoore.com/notes/mouse-position/ seems more reliable than using what the browser provides.
Saving the bounding rectangle from the time of mousedown ensures no it is always calculated against the same rectangle.