### PR TITLE
Add Start and Stop Drawing

### DIFF
--- a/src/components/Annotations.js
+++ b/src/components/Annotations.js
@@ -69,8 +69,8 @@ class Annotations extends Component {
     const rect = this.base.getBoundingClientRect();
     const offsetX = e.clientX - rect.left;
     const offsetY = e.clientY - rect.top;
-    const x = convertWidth.toPercent(offsetX);
-    const y = convertHeight.toPercent(offsetY);
+    const x = 100 * offsetX / rect.width;
+    const y = 100 * offsetY / rect.height;
     return [
       Math.round(x * 100) / 100,
       Math.round(y * 100) / 100,

--- a/src/main.js
+++ b/src/main.js
@@ -95,6 +95,14 @@ OpenSeadragon.Viewer.prototype.areAnnotationsActive = function areActive() {
   return isPluginActive;
 };
 
+OpenSeadragon.Viewer.prototype.startDrawing = ifPluginIsActive(function draw() {
+  selectMode('DRAW', Dispatcher, Store);
+});
+
+OpenSeadragon.Viewer.prototype.stopDrawing = ifPluginIsActive(function stopdraw() {
+  selectMode('MOVE', Dispatcher, Store);
+});
+
 OpenSeadragon.Viewer.prototype.shutdownAnnotations = ifPluginIsActive(function shutdown() {
   if (openHandler !== null) {
     throw new Error('An untriggered handler for the \'open\' event has been found');


### PR DESCRIPTION
allows user to use viewer.startDrawing() and stopDrawing() to toggle between the draw and pan buttons for customizable interface experience.